### PR TITLE
[#47] 의존성 주입 방식 변경

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/ht/project/realtimedeliverymarket/cache/service/RedisCacheService.java
+++ b/src/main/java/com/ht/project/realtimedeliverymarket/cache/service/RedisCacheService.java
@@ -8,16 +8,21 @@ import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 
+/**
+ * Spring cache 로 변경 예정.
+ */
 @Service
 public class RedisCacheService {
 
   private final static String SPRING_CACHE_PREFIX = "spring:";
   private final static String SPRING_CACHE_SEPARATOR = ":";
 
-  @Autowired
-  @Qualifier("cacheStrRedisTemplate")
-  private StringRedisTemplate cacheStrRedisTemplate;
+  private final StringRedisTemplate cacheStrRedisTemplate;
 
+  public RedisCacheService(@Qualifier("cacheStrRedisTemplate")
+                                     StringRedisTemplate cacheStrRedisTemplate) {
+    this.cacheStrRedisTemplate = cacheStrRedisTemplate;
+  }
 
   public String createSpringCacheKey (SpringCacheType cacheType, String suffix) {
 

--- a/src/main/java/com/ht/project/realtimedeliverymarket/category/controller/CategoryController.java
+++ b/src/main/java/com/ht/project/realtimedeliverymarket/category/controller/CategoryController.java
@@ -1,16 +1,16 @@
 package com.ht.project.realtimedeliverymarket.category.controller;
 
 import com.ht.project.realtimedeliverymarket.category.service.CategoryService;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/categories")
 public class CategoryController {
 
-  @Autowired
-  private CategoryService categoryService;
+  private final CategoryService categoryService;
 
   @PostMapping
   public HttpStatus addMainCategory (@RequestBody String name) {

--- a/src/main/java/com/ht/project/realtimedeliverymarket/category/service/CategoryService.java
+++ b/src/main/java/com/ht/project/realtimedeliverymarket/category/service/CategoryService.java
@@ -2,14 +2,15 @@ package com.ht.project.realtimedeliverymarket.category.service;
 
 import com.ht.project.realtimedeliverymarket.category.model.entity.Category;
 import com.ht.project.realtimedeliverymarket.category.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class CategoryService {
 
-  @Autowired
-  private CategoryRepository categoryRepository;
+  private final CategoryRepository categoryRepository;
 
   public void addMainCategory(String name) {
 

--- a/src/main/java/com/ht/project/realtimedeliverymarket/member/controller/MemberController.java
+++ b/src/main/java/com/ht/project/realtimedeliverymarket/member/controller/MemberController.java
@@ -4,26 +4,25 @@ import com.ht.project.realtimedeliverymarket.member.model.dto.MemberJoinDto;
 import com.ht.project.realtimedeliverymarket.member.model.dto.MemberLoginDto;
 import com.ht.project.realtimedeliverymarket.member.service.LoginService;
 import com.ht.project.realtimedeliverymarket.member.service.MemberService;
-
-import javax.servlet.http.HttpSession;
-import javax.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.http.HttpSession;
+import javax.validation.Valid;
+
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/members")
 public class MemberController {
 
-  @Autowired
-  private MemberService memberService;
+  private final MemberService memberService;
 
-  @Autowired
-  private LoginService loginService;
+  private final LoginService loginService;
 
   @PostMapping
   public HttpStatus join(@RequestBody @Valid MemberJoinDto memberJoinDto) {

--- a/src/main/java/com/ht/project/realtimedeliverymarket/member/service/MemberService.java
+++ b/src/main/java/com/ht/project/realtimedeliverymarket/member/service/MemberService.java
@@ -5,7 +5,7 @@ import com.ht.project.realtimedeliverymarket.member.model.dto.MemberJoinDto;
 import com.ht.project.realtimedeliverymarket.member.model.entity.Member;
 import com.ht.project.realtimedeliverymarket.member.model.vo.MemberCache;
 import com.ht.project.realtimedeliverymarket.member.repository.MemberRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,10 +13,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Optional;
 
 @Service
+@RequiredArgsConstructor
 public class MemberService {
 
-  @Autowired
-  private MemberRepository memberRepository;
+  private final MemberRepository memberRepository;
 
   @Transactional
   public Member join(MemberJoinDto memberJoinDto) {

--- a/src/main/java/com/ht/project/realtimedeliverymarket/member/service/SessionLoginService.java
+++ b/src/main/java/com/ht/project/realtimedeliverymarket/member/service/SessionLoginService.java
@@ -8,7 +8,7 @@ import com.ht.project.realtimedeliverymarket.member.model.dto.MemberLoginDto;
 import com.ht.project.realtimedeliverymarket.member.model.entity.Member;
 import com.ht.project.realtimedeliverymarket.member.model.vo.MemberCache;
 import com.ht.project.realtimedeliverymarket.member.repository.MemberRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.serializer.SerializationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,18 +17,16 @@ import javax.servlet.http.HttpSession;
 import java.time.Duration;
 
 @Service
+@RequiredArgsConstructor
 public class SessionLoginService implements LoginService{
 
   public static final String MEMBER_SESSION_KEY = "account";
 
-  @Autowired
-  private MemberRepository memberRepository;
+  private final MemberRepository memberRepository;
 
-  @Autowired
-  private RedisCacheService redisCacheService;
+  private final RedisCacheService redisCacheService;
 
-  @Autowired
-  private ObjectMapper objectMapper;
+  private final ObjectMapper objectMapper;
 
   @Transactional
   @Override

--- a/src/main/java/com/ht/project/realtimedeliverymarket/point/service/PointService.java
+++ b/src/main/java/com/ht/project/realtimedeliverymarket/point/service/PointService.java
@@ -4,19 +4,19 @@ import com.ht.project.realtimedeliverymarket.member.repository.MemberRepository;
 import com.ht.project.realtimedeliverymarket.point.model.dto.PointSaveDto;
 import com.ht.project.realtimedeliverymarket.point.model.entity.Point;
 import com.ht.project.realtimedeliverymarket.point.repository.PointRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
 
 @Service
+@RequiredArgsConstructor
 public class PointService {
 
-  @Autowired
-  private PointRepository pointRepository;
+  private final PointRepository pointRepository;
 
-  @Autowired
-  private MemberRepository memberRepository;
+  private final MemberRepository memberRepository;
 
   @Transactional
   public Point savePoint(Long memberId, PointSaveDto pointSaveDto) {


### PR DESCRIPTION
- 필드 주입 -> 생성자 주입
- 필드 주입은 DI 프레임워크, 즉 스프링에 의존한 방식입니다. 
  - 단위 테스트가 어렵고, `@SpringBootTest`와 같은 통합테스트에서 사용합니다.
  - DI 프레임워크가 없으면 사용이 어렵습니다.
- 생성자 주입은 객체 생성시, 1번만 호출되기 때문에 불변하게 설계할 수 있습니다. (`private final` 을 사용하여 변경을 제한합니다.)
  - 대부분의 의존관계 주입이 발생하면 애플리케이션 종료까지 의존관계가 불변성을 유지해야 합니다.
- 수정자 주입의 경우 `setter`를 통해 주입을 하므로 `public` 지시자를 사용하므로 변경 가능성이 있습니다.